### PR TITLE
Sweets/register and airdrop dna

### DIFF
--- a/deployments/2023-08-08.mainnet.json
+++ b/deployments/2023-08-08.mainnet.json
@@ -1,0 +1,143 @@
+{
+  "allowlistMinter": {
+    "deploy": {
+      "deployedTo": "0xCB1a9309B401382d3d3071B479FDfA0691f6673A",
+      "deployer": "0x4D977d9aEceC3776DD73F2f9080C9AF3BC31f505",
+      "transactionHash": "0x7822d4330eb8c958580dec0bada8f2f65478d807c1c661779418c866f228b1f3"
+    },
+    "contractName": "AllowlistMinter",
+    "contractPath": "src/minter/AllowlistMinter.sol",
+    "args": [
+      "0x8dDeF0396d4B61Fcbb0e4a821DfAC52c011f79dA",
+      "0x14B9df14151A8417106DF244fAF20b6CeC2ad7B6",
+      "0xf253A36Fb30d0DdB654953508F9c59aaD877A3f7",
+      "0x86558b0CD2310382344e4Ee52B1922dDDbb52D31"
+    ]
+  },
+  "familyFriendsMinter": {
+    "deploy": {
+      "deployedTo": "0x86558b0CD2310382344e4Ee52B1922dDDbb52D31",
+      "deployer": "0x4D977d9aEceC3776DD73F2f9080C9AF3BC31f505",
+      "transactionHash": "0x868a76333e40def911d238d6e91856b82f0378ef3805d4ebe0aaa4297f25821e"
+    },
+    "contractName": "FriendsAndFamilyMinter",
+    "contractPath": "src/minter/FriendsAndFamilyMinter.sol",
+    "args": [
+      "0x8dDeF0396d4B61Fcbb0e4a821DfAC52c011f79dA",
+      "0x14B9df14151A8417106DF244fAF20b6CeC2ad7B6"
+    ]
+  },
+  "transferHook": {
+    "deploy": {
+      "deployedTo": "0x24D0aC14793447F54F20870798816a91790a6448",
+      "deployer": "0x4D977d9aEceC3776DD73F2f9080C9AF3BC31f505",
+      "transactionHash": "0xfb322966cde80af04341df35cbf0121998affb2af235eaa018fda3cd32cfe67f"
+    },
+    "contractName": "TransferHook",
+    "contractPath": "src/hooks/Transfers.sol",
+    "args": [
+      "0x8dDeF0396d4B61Fcbb0e4a821DfAC52c011f79dA",
+      "0x02101dfB77FDE026414827Fdc604ddAF224F0921",
+      "0x2D25602551487C3f3354dD80D76D54383A243358"
+    ]
+  },
+  "initialize": {
+    "deploy": {
+      "deployedTo": "0xE14203ACA36026D8d9ea962F530bb39794DF6cFb",
+      "deployer": "0x4D977d9aEceC3776DD73F2f9080C9AF3BC31f505",
+      "transactionHash": "0x970eba90039977856718e343eb1f32e7eb52f57e8d5f2f3deba99456503779e7"
+    },
+    "contractName": "Initializer",
+    "contractPath": "src/Initializer.sol",
+    "args": null
+  },
+  "lockup": {
+    "deploy": {
+      "deployedTo": "0xE23142d4757F70dAe18B26e3B4a0E5B1E1b4F6f0",
+      "deployer": "0x4D977d9aEceC3776DD73F2f9080C9AF3BC31f505",
+      "transactionHash": "0x3acd85b46ab91d7fbb7ac50d4cdf7cba33a4c28f272447b30991b4e45ed890b0"
+    },
+    "contractName": "Lockup",
+    "contractPath": "src/utils/Lockup.sol",
+    "args": null
+  },
+  "minterUtilities": {
+    "deploy": {
+      "deployedTo": "0x14B9df14151A8417106DF244fAF20b6CeC2ad7B6",
+      "deployer": "0x4D977d9aEceC3776DD73F2f9080C9AF3BC31f505",
+      "transactionHash": "0x435ad4d3874327e590e98572fbd8df056fad4bdc70a64d8b048c004e7fdd402c"
+    },
+    "contractName": "MinterUtilities",
+    "contractPath": "src/utils/MinterUtilities.sol",
+    "args": [
+      "0x8dDeF0396d4B61Fcbb0e4a821DfAC52c011f79dA",
+      "50000000000000000",
+      "100000000000000000",
+      "150000000000000000"
+    ]
+  },
+  "ownerOfHook": {
+    "deploy": {
+      "deployedTo": "0xaC6EF7FBB34ccC4C098875B02bF7FAFb82a01c7e",
+      "deployer": "0x4D977d9aEceC3776DD73F2f9080C9AF3BC31f505",
+      "transactionHash": "0x2fe2da30d199001f55ff4bf5b4ddce498192c7eb58c3d318d88860b0f2b6f5ac"
+    },
+    "contractName": "OwnerOfHook",
+    "contractPath": "src/hooks/OwnerOf.sol",
+    "args": []
+  },
+  "passportMinter": {
+    "deploy": {
+      "deployedTo": "0xf253A36Fb30d0DdB654953508F9c59aaD877A3f7",
+      "deployer": "0x4D977d9aEceC3776DD73F2f9080C9AF3BC31f505",
+      "transactionHash": "0xf3ea78d9335cfc3d96aaf14b30e98ad3cb39f8bc429984132e6d45642bd7e38a"
+    },
+    "contractName": "CollectionHolderMint",
+    "contractPath": "src/minter/CollectionHolderMint.sol",
+    "args": [
+      "0x8dDeF0396d4B61Fcbb0e4a821DfAC52c011f79dA",
+      "0x31E28672F704d6F8204e41Ec0B93EE2b1172558E",
+      "0x14B9df14151A8417106DF244fAF20b6CeC2ad7B6",
+      "0x86558b0CD2310382344e4Ee52B1922dDDbb52D31"
+    ]
+  },
+  "publicMinter": {
+    "deploy": {
+      "deployedTo": "0x270900Dabe19e08e08078087a5694A36bD6D9Cd5",
+      "deployer": "0x4D977d9aEceC3776DD73F2f9080C9AF3BC31f505",
+      "transactionHash": "0xcd18698d6a20b0e969ed1e0bbe11577178a1a5f83d91a7923e921ebe8b2a1680"
+    },
+    "contractName": "PublicMinter",
+    "contractPath": "src/minter/PublicMinter.sol",
+    "args": [
+      "0x8dDeF0396d4B61Fcbb0e4a821DfAC52c011f79dA",
+      "0x14B9df14151A8417106DF244fAF20b6CeC2ad7B6",
+      "0xf253A36Fb30d0DdB654953508F9c59aaD877A3f7",
+      "0x86558b0CD2310382344e4Ee52B1922dDDbb52D31"
+    ]
+  },
+  "staking": {
+    "deploy": {
+      "deployedTo": "0xF7bfF0B8E59143a39271a4cA1B2D8De65FF7E658",
+      "deployer": "0x4D977d9aEceC3776DD73F2f9080C9AF3BC31f505",
+      "transactionHash": "0xb4fd19d9e14dac4435f14c7bf37f0abfa308142bf9b4ed7d7228e192498eee88"
+    },
+    "contractName": "Cre8ing",
+    "contractPath": "src/Cre8ing.sol",
+    "args": null
+  },
+  "subscription": {
+    "deploy": {
+      "deployedTo": "0x4571246C26F062DCCfFdfc9bd9Faf6f6eec8D083",
+      "deployer": "0x4D977d9aEceC3776DD73F2f9080C9AF3BC31f505",
+      "transactionHash": "0xf9942fcfd16f7162ecf1f224cee13e9f757660bdbd60a84c8acf17d4b0f52d42"
+    },
+    "contractName": "Subscription",
+    "contractPath": "src/subscription/Subscription.sol",
+    "args": [
+      "0x8dDeF0396d4B61Fcbb0e4a821DfAC52c011f79dA",
+      86400,
+      38580246913
+    ]
+  }
+}

--- a/scripts/deploy.mjs
+++ b/scripts/deploy.mjs
@@ -14,6 +14,7 @@ import { deploySubscription } from "./deploy/deploySubscription.mjs";
 import { deployInitializer } from "./deploy/deployInitializer.mjs";
 import { deployOwnerOf } from "./deploy/deployOwnerOf.mjs";
 import { deployDna } from "./deploy/deployDna.mjs";
+import { deployDnaMinter } from "./deploy/deployDnaMinter.mjs";
 
 dotenv.config({
   path: `.env.${process.env.CHAIN}`,
@@ -25,35 +26,35 @@ export async function setupContracts() {
     "0x36c161febf4b54734baf31a4d6b00da9f4a1cc6eeae64bb328e095b1ab00ec96";
   const initialize = await deployInitializer();
   const cre8ors = await deployCre8ors(presaleMerkleRoot);
+  const cre8orsAddress = cre8ors.deploy.deployedTo;
   const dna = await deployDna();
-  const subscription = await deploySubscription(cre8ors.deploy.deployedTo);
+  const dnaMinter = await deployDnaMinter();
+  const subscription = await deploySubscription(cre8orsAddress);
   const ownerOfHook = await deployOwnerOf();
-  const transferHook = await deployTransfers(cre8ors.deploy.deployedTo);
+  const transferHook = await deployTransfers(cre8orsAddress);
   const staking = await deployStaking();
   const lockup = await deployLockup();
   const passportAddress = "0x31E28672F704d6F8204e41Ec0B93EE2b1172558E";
 
-  const minterUtilities = await deployMinterUtilities(
-    cre8ors.deploy.deployedTo
-  );
+  const minterUtilities = await deployMinterUtilities(cre8orsAddress);
   const familyFriendsMinter = await deployFamilyAndFriendsMinter(
-    cre8ors.deploy.deployedTo,
+    cre8orsAddress,
     minterUtilities.deploy.deployedTo
   );
   const passportMinter = await deployPassportMinter(
-    cre8ors.deploy.deployedTo,
+    cre8orsAddress,
     passportAddress,
     minterUtilities.deploy.deployedTo,
     familyFriendsMinter.deploy.deployedTo
   );
   const allowlistMinter = await deployAllowlistMinter(
-    cre8ors.deploy.deployedTo,
+    cre8orsAddress,
     minterUtilities.deploy.deployedTo,
     passportMinter.deploy.deployedTo,
     familyFriendsMinter.deploy.deployedTo
   );
   const publicMinter = await deployPublicMinter(
-    cre8ors.deploy.deployedTo,
+    cre8orsAddress,
     minterUtilities.deploy.deployedTo,
     passportMinter.deploy.deployedTo,
     familyFriendsMinter.deploy.deployedTo
@@ -61,6 +62,8 @@ export async function setupContracts() {
   return {
     allowlistMinter,
     cre8ors,
+    dna,
+    dnaMinter,
     familyFriendsMinter,
     transferHook,
     initialize,

--- a/scripts/deploy/deployDnaMinter.mjs
+++ b/scripts/deploy/deployDnaMinter.mjs
@@ -1,0 +1,21 @@
+import { deployAndVerify } from "../contract.mjs";
+import dotenv from "dotenv";
+
+dotenv.config({
+  path: `.env.${process.env.CHAIN}`,
+});
+
+export async function deployDnaMinter(_cre8orsNft, _dnaNft) {
+  console.log("deploying DNA Minter");
+  const _registry = "0x02101dfB77FDE026414827Fdc604ddAF224F0921";
+  const _implementation = "0x2d25602551487c3f3354dd80d76d54383a243358";
+  const contractLocation = "src/minter/DNAMinter.sol:DNAMinter";
+  const args = [_cre8orsNft, _dnaNft, _registry, _implementation];
+  const contract = await deployAndVerify(contractLocation, args);
+  const contractAddress = contract.deployed.deploy.deployedTo;
+  console.log("deployed dna minter to ", contractAddress);
+  console.log(
+    "make sure to grant dna.grantRole(DEFAULT_MINTER_ROLE, initializer)"
+  );
+  return contract.deployed;
+}

--- a/src/minter/DNAMinter.sol
+++ b/src/minter/DNAMinter.sol
@@ -10,11 +10,13 @@ import {Admin} from "../subscription/abstracts/Admin.sol";
 import {IERC6551Registry} from "lib/ERC6551/src/interfaces/IERC6551Registry.sol";
 
 contract DNAMinter is Cre8orsERC6551, Admin {
-    ///@notice error - already minted DNA Card for cre8or.
+    /// @notice Error event for attempting to mint a DNA Card that has already been minted.
     error DNAMinter_AlreadyMinted();
-    ///@notice The address of the collection contract for Cre8ors.
+
+    /// @notice The address of the collection contract for Cre8ors.
     address public cre8orsNft;
-    ///@notice The address of the collection contract for DNA airdrops.
+
+    /// @notice The address of the collection contract for Cre8ors DNA cards.
     address public dnaNft;
 
     /// @notice Initializes the contract with the address of the Cre8orsNFT contract.
@@ -32,6 +34,9 @@ contract DNAMinter is Cre8orsERC6551, Admin {
         dnaNft = _dnaNft;
     }
 
+    /// @notice Creates a Token Bound Account (TBA) and mints a DNA NFT.
+    /// @param _cre8orsTokenId Token ID of the Cre8ors NFT for which DNA will be minted.
+    /// @return _mintedDnaTokenId ID of the minted DNA token.
     function createTokenBoundAccountAndMintDNA(
         uint256 _cre8orsTokenId
     )
@@ -47,6 +52,8 @@ contract DNAMinter is Cre8orsERC6551, Admin {
         _mintedDnaTokenId = ICre8ors(dnaNft).adminMint(airdropList[0], 1);
     }
 
+    /// @notice Modifier to allow minting only if it is the first mint for the given Cre8ors token ID.
+    /// @param _cre8orsTokenId Token ID to check for first minting.
     modifier onlyFirstMint(uint256 _cre8orsTokenId) {
         address tba = IERC6551Registry(erc6551Registry).account(
             erc6551AccountImplementation,
@@ -70,14 +77,16 @@ contract DNAMinter is Cre8orsERC6551, Admin {
         dnaNft = _dnaNft;
     }
 
-    /// @notice Set ERC6551 registry
-    /// @param _registry ERC6551 registry
+    /// @notice Set the ERC6551 registry address.
+    /// @dev This function can only be called by an admin.
+    /// @param _registry Address of the ERC6551 registry to be set.
     function setErc6551Registry(address _registry) public onlyAdmin(dnaNft) {
         erc6551Registry = _registry;
     }
 
-    /// @notice Set ERC6551 account implementation
-    /// @param _implementation ERC6551 account implementation
+    /// @notice Set the ERC6551 account implementation address.
+    /// @dev This function can only be called by an admin.
+    /// @param _implementation Address of the ERC6551 account implementation to be set.
     function setErc6551Implementation(
         address _implementation
     ) public onlyAdmin(dnaNft) {

--- a/src/minter/DNAMinter.sol
+++ b/src/minter/DNAMinter.sol
@@ -9,19 +9,35 @@ import {ISubscription} from "../subscription/interfaces/ISubscription.sol";
 import {Admin} from "../subscription/abstracts/Admin.sol";
 
 contract DNAMinter is Cre8orsERC6551, Admin {
+    ///@notice The address of the collection contract for Cre8ors.
+    address public cre8orsNft;
     ///@notice The address of the collection contract for DNA airdrops.
     address public dnaNft;
 
     /// @notice Initializes the contract with the address of the Cre8orsNFT contract.
+    /// @param _cre8orsNft The address of the Cre8ors contract to be used.
     /// @param _dnaNft The address of the Cre8ors DNA contract to be used.
     /// @param _registry The address of the ERC6551 registry contract to be used.
     /// @param _implementation The address of the ERC6551 implementation contract to be used.
     constructor(
+        address _cre8orsNft,
         address _dnaNft,
         address _registry,
         address _implementation
     ) Cre8orsERC6551(_registry, _implementation) {
+        cre8orsNft = _cre8orsNft;
         dnaNft = _dnaNft;
+    }
+
+    function createTokenBoundAccountAndMintDNA(
+        uint256 _cre8orsTokenId
+    ) public returns (uint256 _mintedDnaTokenId) {
+        address[] memory airdropList = createTokenBoundAccounts(
+            cre8orsNft,
+            _cre8orsTokenId,
+            1
+        );
+        _mintedDnaTokenId = ICre8ors(dnaNft).adminMint(airdropList[0], 1);
     }
 
     /// @notice Set the Cre8orsNFT contract address.

--- a/src/minter/DNAMinter.sol
+++ b/src/minter/DNAMinter.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {Cre8orsERC6551} from "../utils/Cre8orsERC6551.sol";
+import {ICre8ors} from "../interfaces/ICre8ors.sol";
+import {ICre8ing} from "../interfaces/ICre8ing.sol";
+import {IERC721Drop} from "../interfaces/IERC721Drop.sol";
+import {ISubscription} from "../subscription/interfaces/ISubscription.sol";
+import {Admin} from "../subscription/abstracts/Admin.sol";
+
+contract DNAMinter is Cre8orsERC6551, Admin {
+    ///@notice The address of the collection contract for DNA airdrops.
+    address public dnaNft;
+
+    /// @notice Initializes the contract with the address of the Cre8orsNFT contract.
+    /// @param _dnaNft The address of the Cre8ors DNA contract to be used.
+    /// @param _registry The address of the ERC6551 registry contract to be used.
+    /// @param _implementation The address of the ERC6551 implementation contract to be used.
+    constructor(
+        address _dnaNft,
+        address _registry,
+        address _implementation
+    ) Cre8orsERC6551(_registry, _implementation) {
+        dnaNft = _dnaNft;
+    }
+
+    /// @notice Set the Cre8orsNFT contract address.
+    /// @dev This function can only be called by an admin, identified by the
+    ///     "cre8orsNFT" contract address.
+    /// @param _dnaNft The new address of the DNA contract to be set.
+    function setDnaNFT(address _dnaNft) public onlyAdmin(dnaNft) {
+        dnaNft = _dnaNft;
+    }
+
+    /// @notice Set ERC6551 registry
+    /// @param _registry ERC6551 registry
+    function setErc6551Registry(address _registry) public onlyAdmin(dnaNft) {
+        erc6551Registry = _registry;
+    }
+
+    /// @notice Set ERC6551 account implementation
+    /// @param _implementation ERC6551 account implementation
+    function setErc6551Implementation(
+        address _implementation
+    ) public onlyAdmin(dnaNft) {
+        erc6551AccountImplementation = _implementation;
+    }
+}

--- a/src/utils/Cre8orsERC6551.sol
+++ b/src/utils/Cre8orsERC6551.sol
@@ -11,26 +11,32 @@ import {IERC6551Registry} from "lib/ERC6551/src/interfaces/IERC6551Registry.sol"
 ╚██████╗██║  ██║███████╗╚█████╔╝╚██████╔╝██║  ██║███████║
  ╚═════╝╚═╝  ╚═╝╚══════╝ ╚════╝  ╚═════╝ ╚═╝  ╚═╝╚══════╝                                                       
  */
+/// @title Cre8orsERC6551 contract for handling ERC6551 token-bound accounts.
 /// @dev inspiration: https://github.com/ourzora/zora-drops-contracts
 contract Cre8orsERC6551 {
-    /// @dev The address of ERC6551 Registry
+    /// @notice The address of ERC6551 Registry contract.
     address public erc6551Registry;
 
-    /// @dev The address of ERC6551 Account Implementation
+    /// @notice The address of ERC6551 Account Implementation contract.
     address public erc6551AccountImplementation;
 
+    /// @notice Initializes the Cre8orsERC6551 contract with ERC6551 Registry and Implementation addresses.
+    /// @param _registry The address of the ERC6551 registry contract.
+    /// @param _implementation The address of the ERC6551 account implementation contract.
     constructor(address _registry, address _implementation) {
         erc6551Registry = _registry;
         erc6551AccountImplementation = _implementation;
     }
 
-    /// @dev Initial data for ERC6551 createAccount
+    /// @dev Initial data for ERC6551 createAccount function.
     bytes public constant INIT_DATA = "0x8129fc1c";
 
-    /// @notice creates TBA with ERC6551
-    /// @param _target target ERC721 contract
-    /// @param startTokenId tokenID to start from
-    /// @param quantity number of tokens to createAccount for
+    /// @notice Creates Token Bound Accounts (TBA) with ERC6551.
+    /// @dev Internal function used to create TBAs for a given ERC721 contract.
+    /// @param _target Target ERC721 contract address.
+    /// @param startTokenId Token ID to start from.
+    /// @param quantity Number of token-bound accounts to create.
+    /// @return airdropList An array containing the addresses of the created TBAs.
     function createTokenBoundAccounts(
         address _target,
         uint256 startTokenId,

--- a/test/minter/FriendsAndFamilyMinter.t.sol
+++ b/test/minter/FriendsAndFamilyMinter.t.sol
@@ -146,6 +146,34 @@ contract FriendsAndFamilyMinterTest is DSTest, Cre8orTestBase {
         assertTrue(!subscription.isSubscriptionValid(tokenId));
     }
 
+    function testSuccesfulAddDiscount_Array(
+        address _friendOrFamily1,
+        address _friendOrFamily2,
+        address _friendOrFamily3
+    ) public {
+        vm.assume(_friendOrFamily1 != address(0));
+        vm.assume(_friendOrFamily2 != address(0));
+        vm.assume(_friendOrFamily3 != address(0));
+
+        // Setup Minter
+        _setupMinter();
+
+        // Apply Discount
+        address[] memory recipients = new address[](3);
+        recipients[0] = _friendOrFamily1;
+        recipients[1] = _friendOrFamily2;
+        recipients[2] = _friendOrFamily3;
+
+        // Apply Discount
+        _addDiscount(recipients);
+
+        // ERC6551 setup
+        _setupErc6551();
+
+        // Asserts
+        assertTrue(minter.hasDiscount(_friendOrFamily1));
+    }
+
     function testRevertNoDiscount(address _buyer) public {
         // Setup Minter
         _setupMinter();
@@ -213,6 +241,17 @@ contract FriendsAndFamilyMinterTest is DSTest, Cre8orTestBase {
         vm.prank(DEFAULT_OWNER_ADDRESS);
         minter.addDiscount(_buyer);
         assertTrue(minter.hasDiscount(_buyer));
+    }
+
+    function _addDiscount(address[] memory _friends) internal {
+        for (uint256 i = 0; i < _friends.length; i++) {
+            assertTrue(!minter.hasDiscount(_friends[i]));
+        }
+        vm.prank(DEFAULT_OWNER_ADDRESS);
+        minter.addDiscount(_friends);
+        for (uint256 i = 0; i < _friends.length; i++) {
+            assertTrue(minter.hasDiscount(_friends[i]));
+        }
     }
 
     function _setMinterRole(address _assignee) internal {

--- a/test/utils/DNAMinter.t.sol
+++ b/test/utils/DNAMinter.t.sol
@@ -27,6 +27,8 @@ contract DNATest is DSTest, Cre8orTestBase {
     Cre8ors dna;
     DNAMinter dnaMinter;
     bytes32 public constant DEFAULT_ADMIN_ROLE = 0x00;
+    ///@notice error - already minted DNA Card for cre8or.
+    error DNAMinter_AlreadyMinted();
 
     function setUp() public {
         Cre8orTestBase.cre8orSetup();
@@ -63,6 +65,16 @@ contract DNATest is DSTest, Cre8orTestBase {
 
         // Registers with ERC6551 & mint DNA to TBA
         _createTbaAndMint(_quantity);
+    }
+
+    function test_createAccountAndMintDNA_revert_AlreadyMinted(
+        uint256 _quantity
+    ) public {
+        address tokenBoundAccount = getTBA(_quantity);
+        test_createAccountAndMintDNA(_quantity);
+        vm.expectRevert(DNAMinter_AlreadyMinted.selector);
+        dnaMinter.createTokenBoundAccountAndMintDNA(_quantity);
+        assertEq(dna.balanceOf(tokenBoundAccount), 1);
     }
 
     function _grantDnaMinterAdminRole() internal {

--- a/test/utils/DNAMinter.t.sol
+++ b/test/utils/DNAMinter.t.sol
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.15;
+
+import {DSTest} from "ds-test/test.sol";
+import {Cre8ors} from "../../src/Cre8ors.sol";
+import {IERC721Drop} from "../../src/interfaces/IERC721Drop.sol";
+import {IERC721A} from "lib/ERC721A/contracts/IERC721A.sol";
+import {ERC6551Registry} from "lib/ERC6551/src/ERC6551Registry.sol";
+import {Account} from "lib/tokenbound/src/Account.sol";
+import {Cre8ing} from "../../src/Cre8ing.sol";
+import {TransferHook} from "../../src/hooks/Transfers.sol";
+import {Cre8orTestBase} from "./Cre8orTestBase.sol";
+import {IERC721ACH} from "ERC721H/interfaces/IERC721ACH.sol";
+import {IERC6551Registry} from "lib/ERC6551/src/interfaces/IERC6551Registry.sol";
+import {Subscription} from "../../src/subscription/Subscription.sol";
+import {DNAMinter} from "../../src/minter/DNAMinter.sol";
+import "forge-std/console.sol";
+
+error NotAuthorized();
+
+contract DNATest is DSTest, Cre8orTestBase {
+    Cre8ing public cre8ingBase;
+    address constant DEAD_ADDRESS =
+        address(0x000000000000000000000000000000000000dEaD);
+    Subscription public subscription;
+    Cre8ors dna;
+    DNAMinter dnaMinter;
+
+    function setUp() public {
+        Cre8orTestBase.cre8orSetup();
+        dna = _deployCre8or();
+    }
+
+    function test_Erc6551Registry() public {
+        _setupErc6551();
+        address tokenBoundAccount = getTBA(1);
+        assertTrue(!isContract(tokenBoundAccount));
+    }
+
+    function test_setErc6551Registry_revert_Access_OnlyAdmin() public {
+        vm.expectRevert(IERC721Drop.Access_OnlyAdmin.selector);
+        transferHook.setErc6551Registry(address(erc6551Registry));
+    }
+
+    function test_setErc6551Implementation_revert_Access_OnlyAdmin() public {
+        vm.expectRevert(IERC721Drop.Access_OnlyAdmin.selector);
+        transferHook.setErc6551Implementation(address(erc6551Implementation));
+    }
+
+    function test_createAccount(uint256 _quantity) public {
+        vm.assume(_quantity > 0);
+        vm.assume(_quantity < 18);
+
+        address tokenBoundAccount = getTBA(_quantity);
+        assertTrue(!isContract(tokenBoundAccount));
+
+        // MINT REGISTERS WITH ERC6511
+        cre8orsNFTBase.purchase(_quantity);
+        emit log_address(address(tokenBoundAccount));
+        assertTrue(isContract(tokenBoundAccount));
+    }
+
+    function test_sendWithTBA(
+        uint256 _initialQuantity,
+        uint256 _smartWalletQuantity
+    ) public {
+        vm.assume(_initialQuantity > 0);
+        vm.assume(_initialQuantity < 19);
+        vm.assume(_smartWalletQuantity > 0);
+        vm.assume(_smartWalletQuantity < 19);
+
+        address payable tokenBoundAccount = payable(getTBA(_initialQuantity));
+
+        // MINT REGISTERS WITH ERC6511
+        assertTrue(!isContract(tokenBoundAccount));
+        cre8orsNFTBase.purchase(_initialQuantity);
+        assertTrue(isContract(tokenBoundAccount));
+
+        // TBA used to mint another CRE8OR
+        assertEq(cre8orsNFTBase.balanceOf(tokenBoundAccount), 0);
+        uint256 value;
+        bytes memory data = abi.encodeWithSignature(
+            "purchase(uint256)",
+            _smartWalletQuantity
+        );
+        bytes memory response = Account(tokenBoundAccount).executeCall(
+            address(cre8orsNFTBase),
+            value,
+            data
+        );
+        uint256 tokenId = abi.decode(response, (uint256));
+        assertEq(
+            cre8orsNFTBase.balanceOf(tokenBoundAccount),
+            _smartWalletQuantity
+        );
+
+        // use TBA to burn CRE8OR
+        data = abi.encodeWithSignature(
+            "safeTransferFrom(address,address,uint256)",
+            tokenBoundAccount,
+            DEAD_ADDRESS,
+            tokenId + 1
+        );
+        Account(tokenBoundAccount).executeCall(
+            address(cre8orsNFTBase),
+            value,
+            data
+        );
+        assertEq(
+            cre8orsNFTBase.balanceOf(tokenBoundAccount),
+            _smartWalletQuantity - 1
+        );
+    }
+
+    function test_sendWithTBA_revert_NotAuthorized(
+        uint256 _initialQuantity,
+        uint256 _smartWalletQuantity
+    ) public {
+        vm.assume(_initialQuantity > 0);
+        vm.assume(_initialQuantity < 19);
+        vm.assume(_smartWalletQuantity > 0);
+        vm.assume(_smartWalletQuantity < 19);
+
+        address payable tokenBoundAccount = payable(getTBA(_initialQuantity));
+
+        // MINT REGISTERS WITH ERC6511
+        assertTrue(!isContract(tokenBoundAccount));
+        vm.prank(DEFAULT_OWNER_ADDRESS);
+        cre8orsNFTBase.purchase(_initialQuantity);
+        assertTrue(isContract(tokenBoundAccount));
+
+        // TBA used to mint another CRE8OR
+        assertEq(cre8orsNFTBase.balanceOf(tokenBoundAccount), 0);
+        uint256 value;
+        bytes memory data = abi.encodeWithSignature(
+            "purchase(uint256)",
+            _smartWalletQuantity
+        );
+        vm.expectRevert(NotAuthorized.selector);
+        Account(tokenBoundAccount).executeCall(
+            address(cre8orsNFTBase),
+            value,
+            data
+        );
+        assertEq(cre8orsNFTBase.balanceOf(tokenBoundAccount), 0);
+    }
+
+    function test_transfer_only(uint256 _quantity) public {
+        vm.assume(_quantity < 100);
+        vm.assume(_quantity > 0);
+
+        // ERC6551 setup
+        _setupErc6551();
+
+        address BUYER = address(0x123);
+        vm.startPrank(BUYER);
+        cre8orsNFTBase.purchase(_quantity);
+        for (uint256 i = 1; i <= _quantity; i++) {
+            cre8orsNFTBase.safeTransferFrom(BUYER, DEAD_ADDRESS, i);
+        }
+    }
+
+    function _setMinterRole(address _assignee) internal {
+        vm.startPrank(DEFAULT_OWNER_ADDRESS);
+        cre8orsNFTBase.grantRole(
+            cre8orsNFTBase.MINTER_ROLE(),
+            address(_assignee)
+        );
+        vm.stopPrank();
+    }
+
+    function _setupSubscriptionContract(
+        Cre8ors cre8orsNFT_
+    ) internal returns (Subscription _subscription) {
+        _subscription = new Subscription({
+            cre8orsNFT_: address(cre8orsNFT_),
+            minRenewalDuration_: 1 days,
+            pricePerSecond_: 38580246913 // Roughly calculates to 0.1 ether per 30 days
+        });
+    }
+
+    function _setupTransferHook() internal returns (TransferHook) {
+        transferHook = new TransferHook(
+            address(cre8orsNFTBase),
+            address(erc6551Registry),
+            address(erc6551Implementation)
+        );
+        _setMinterRole(address(transferHook));
+
+        vm.startPrank(DEFAULT_OWNER_ADDRESS);
+        // set hook
+        cre8orsNFTBase.setHook(
+            IERC721ACH.HookType.AfterTokenTransfers,
+            address(transferHook)
+        );
+        // set subscription
+        transferHook.setSubscription(
+            address(cre8orsNFTBase),
+            address(subscription)
+        );
+        vm.stopPrank();
+
+        return transferHook;
+    }
+}


### PR DESCRIPTION
# Deploy TBA for your Cre8or & mint a DNA Card in it
- goal: reduce `mint` costs to reduce friction on purchase.
- solution: decouple `ERC6551` registry & DNA airdrop. 🔌 

### UX
1. I Mint a Cre8or.
2. I share the success Tweet.
3. I am told, by the Cre8ors team, to setup my profile.
4. When I visit my profile, I see a button where Smart Wallet should be.
5. I click the button, opening a transaction to sign `dnaMinter.createTokenBoundAccountAndMintDNA(_tokenId);` 🦊 
6. onSuccess, I see my TBA, with a DNA card inside the wallet on my User Profile.
7. I can click on items in my TBA to send them from TBA => my wallet.